### PR TITLE
Added disposable for HTTPListener

### DIFF
--- a/uhttpsharp/Listeners/IHttpListener.cs
+++ b/uhttpsharp/Listeners/IHttpListener.cs
@@ -1,9 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using uhttpsharp.Clients;
 
 namespace uhttpsharp.Listeners
 {
-    public interface IHttpListener
+    public interface IHttpListener: IDisposable
     {
 
         Task<IClient> GetClient();

--- a/uhttpsharp/Listeners/SslListenerDecoerator.cs
+++ b/uhttpsharp/Listeners/SslListenerDecoerator.cs
@@ -19,5 +19,10 @@ namespace uhttpsharp.Listeners
         {
             return new ClientSslDecorator(await _child.GetClient().ConfigureAwait(false), _certificate);
         }
+
+        public void Dispose()
+        {
+            _child?.Dispose();
+        }
     }
 }

--- a/uhttpsharp/Listeners/SslListenerDecoerator.cs
+++ b/uhttpsharp/Listeners/SslListenerDecoerator.cs
@@ -22,7 +22,7 @@ namespace uhttpsharp.Listeners
 
         public void Dispose()
         {
-            _child?.Dispose();
+            _child.Dispose();
         }
     }
 }

--- a/uhttpsharp/Listeners/TcpListenerAdapter.cs
+++ b/uhttpsharp/Listeners/TcpListenerAdapter.cs
@@ -17,5 +17,10 @@ namespace uhttpsharp.Listeners
         {
             return new TcpClientAdapter(await _listener.AcceptTcpClientAsync().ConfigureAwait(false));
         }
+
+        public void Dispose()
+        {
+            _listener.Stop();
+        }
     }
 }


### PR DESCRIPTION
I added a dispose to the IHttpListener.

This is needed in several scenarios as for example when reloading a DLL as the socket won't be closed until the full application is closed.