### PR TITLE
Fix deadlock when TLS handshake is incomplete

### DIFF
--- a/uhttpsharp/Clients/ClientSslDecoerator.cs
+++ b/uhttpsharp/Clients/ClientSslDecoerator.cs
@@ -1,21 +1,33 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Net;
 using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 
 namespace uhttpsharp.Clients
 {
     public class ClientSslDecorator : IClient
     {
         private readonly IClient _child;
+        private readonly X509Certificate _certificate;
         private readonly SslStream _sslStream;
 
         public ClientSslDecorator(IClient child, X509Certificate certificate)
         {
             _child = child;
+            _certificate = certificate;
             _sslStream = new SslStream(_child.Stream);
-            _sslStream.AuthenticateAsServer(certificate, false, SslProtocols.Tls, true);
+        }
+
+        public async Task AuthenticateAsServer()
+        {
+            Task timeout = Task.Delay(TimeSpan.FromSeconds(10));
+            if (timeout == await Task.WhenAny(_sslStream.AuthenticateAsServerAsync(_certificate, false, SslProtocols.Tls, true), timeout).ConfigureAwait(false))
+            {
+                throw new TimeoutException("SSL Authentication Timeout");
+            }
         }
 
         public Stream Stream

--- a/uhttpsharp/HttpClient.cs
+++ b/uhttpsharp/HttpClient.cs
@@ -64,7 +64,7 @@ namespace uhttpsharp
         {
             if (Client is ClientSslDecorator)
             {
-                await ((ClientSslDecorator)Client).AuthenticateAsServer();
+                await ((ClientSslDecorator)Client).AuthenticateAsServer().ConfigureAwait(false);
             }
 
             _stream = new BufferedStream(_client.Stream, 8096);


### PR DESCRIPTION
This fixes a bug which caused the server to not accept new requests when a TLS handshake was left uncompleted by the client. It also adds a 10 second timeout to the authentication so that it does not hang around forever.