### PR TITLE
Bumped TLS version to 1.2

### DIFF
--- a/uhttpsharp/Clients/ClientSslDecoerator.cs
+++ b/uhttpsharp/Clients/ClientSslDecoerator.cs
@@ -24,7 +24,7 @@ namespace uhttpsharp.Clients
         public async Task AuthenticateAsServer()
         {
             Task timeout = Task.Delay(TimeSpan.FromSeconds(10));
-            if (timeout == await Task.WhenAny(_sslStream.AuthenticateAsServerAsync(_certificate, false, SslProtocols.Tls, true), timeout).ConfigureAwait(false))
+            if (timeout == await Task.WhenAny(_sslStream.AuthenticateAsServerAsync(_certificate, false, SslProtocols.Tls12, true), timeout).ConfigureAwait(false))
             {
                 throw new TimeoutException("SSL Authentication Timeout");
             }


### PR DESCRIPTION
It currently uses TLS 1.0 which is insecure and actually starting to become unsupported by some browsers. I bumped the version to TLS 1.2 which fixes this, while not appearing to break anything in the example program.